### PR TITLE
Monk X: Add Monk Kit on dev branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:14
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install -g npm@latest
+RUN npm install
+COPY . .
+EXPOSE 8080
+CMD [ "npm", "run", "dev" ]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO three.js
+LOAD three.js.yaml

--- a/three.js.yaml
+++ b/three.js.yaml
@@ -1,0 +1,10 @@
+namespace: three.js
+three.js:
+  defines: runnable
+  metadata:
+    name: three.js
+    description: JavaScript 3D library
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    three.js:
+      build: .


### PR DESCRIPTION
I couldn't make the /tmp/85lc7/Dockerfile work and gave up. You can try to fix it yourself. Here's the error I get:


```
[31m✘[0m [31mFailed to build image: image service build failed[0m
Error chain: 
↪ image service build failed
 ↪ new job and wait failed
   [90m(description: , name: job.images.build)[0m
   ↪ scan build response
    ↪ building at STEP "RUN npm install": while running runtime: exit status 1

💡 [90mIf you did not expect this error, please share this code with Monk team:
   H4sIAAAAAAAC/5yQwW7TXBCFX2U0q7Sy7N9/QhPuDhCoQmqF0iIWTRdje3An3My1PNc1UtUtD8Nj8STouolEC0IVS+ue4/nOd3WH6zAauqs7PGMzahkdyo5aBuP+VmqGahDfwGcSzw1m+E58ysyKPoRYdH3Ych2L7ktb7AtWTH07fOdtcIv/U3PQOkrQwwXLZ8cXD5mj/HW6coQZnnGkhiKhQ7zPfsWCH9++g/II21ABaQMjSXwO2DZUVgxRvCWW+eq/xzDpOT/n8X2oXmnziSQ+4WjY6l66FHeQgdKOXYLI9zMmQ09hJ1qrSfcCe7YuqPFfSSsyPujzoZW6mMoJe7l8TD0957PjbajeBI0kyv3zND6gTT8WbYEiXFy+/QAbXH88B+12IGqRvN+gg/FGPEM/qKZoP2iUNJ6/SgSLFAeDcqP/uqksV38alayt97p+23Kd4aloNHQ6eJ/htPiU7AYd3s7zsszLBWZ4KTu2SLsOXXnycnmymK+WL+6vfwYAAP//j/r9SvECAAA=[0m

```

You can fix the error yourself, push to this branch and then merge the PR. Monk will import the kit ayutomatically.
Alternatively, just close the PR.